### PR TITLE
Added Apache 2.0 license to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,12 @@
   <version>1.0-SNAPSHOT</version>
   <name>Splinter weblogging software</name>
   <url>http://maven.apache.org</url>
+  <licenses>
+      <license>
+          <name>Apache 2</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      </license>
+  </licenses>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.7</maven.compiler.source>


### PR DESCRIPTION
It's useful for IDEs like Netbeans, which automatically inject license headers.
